### PR TITLE
[PLT-83] Optimise

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ The following environment variables are supported:
 - `STATSD_PROMETHEUS_OPEN_TIMEOUT`:  The timeout for connecting to the Prometheus backend (default is 2s).
 - `STATSD_PROMETHEUS_READ_TIMEOUT`:  The timeout for reading from the Prometheus backend (default is 10s).
 - `STATSD_PROMETHEUS_WRITE_TIMEOUT`:  The timeout for writing to the Prometheus backend (default is 10s).
+- `STATSD_PROMETHEUS_SECONDS_TO_SLEEP`:  The number of seconds to sleep between checks for needing to flush the buffer (default is 1).
+- `STATSD_PROMETHEUS_SECONDS_BETWEEN_FLUSHES`:  The maximum number of seconds to wait before flushing the buffer (default is 60).
+- `STATSD_PROMETHEUS_MAX_FILL_RATIO`:  The ratio of buffer size to max buffer size at which a flush will be triggered (default is 0.8).
 
 ## StatsD keys
 

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -130,6 +130,18 @@ module StatsD
         Float(env.fetch("STATSD_PROMETHEUS_WRITE_TIMEOUT", "10")).to_i
       end
 
+      def prometheus_seconds_to_sleep
+        Float(env.fetch("STATSD_PROMETHEUS_SECONDS_TO_SLEEP", "1.0")).to_f
+      end
+
+      def prometheus_seconds_between_flushes
+        Float(env.fetch("STATSD_PROMETHEUS_SECONDS_BETWEEN_FLUSHES", "60.0")).to_f
+      end
+
+      def prometheus_max_fill_ratio
+        Float(env.fetch("STATSD_PROMETHEUS_MAX_FILL_RATIO", "0.8")).to_f
+      end
+
       def client
         StatsD::Instrument::Client.from_env(self)
       end
@@ -150,6 +162,9 @@ module StatsD
               open_timeout: prometheus_open_timeout,
               read_timeout: prometheus_read_timeout,
               write_timeout: prometheus_write_timeout,
+              seconds_to_sleep: prometheus_seconds_to_sleep,
+              seconds_between_flushes: prometheus_seconds_between_flushes,
+              max_fill_ratio: prometheus_max_fill_ratio,
             )
           elsif statsd_batching?
             StatsD::Instrument::BatchedUDPSink.for_addr(

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -115,7 +115,8 @@ module StatsD
       end
 
       def statsd_max_packet_size
-        Float(env.fetch("STATSD_MAX_PACKET_SIZE", StatsD::Instrument::BatchedUDPSink::DEFAULT_MAX_PACKET_SIZE))
+        default_statsd_max_packet_size = prometheus? ? StatsD::Instrument::Prometheus::BatchedPrometheusSink::DEFAULT_MAX_PACKET_SIZE : StatsD::Instrument::BatchedUDPSink::DEFAULT_MAX_PACKET_SIZE
+        Float(env.fetch("STATSD_MAX_PACKET_SIZE", default_statsd_max_packet_size))
       end
 
       def prometheus_open_timeout

--- a/lib/statsd/instrument/prometheus/aggregator.rb
+++ b/lib/statsd/instrument/prometheus/aggregator.rb
@@ -7,11 +7,14 @@ module StatsD
         def initialize(datagrams, percentiles = nil)
           @datagrams = datagrams
           @percentiles = percentiles
+          @pre_aggregation_number_of_metrics = 0
         end
 
         def run
           aggregated_datagrams.compact
         end
+
+        attr_reader :pre_aggregation_number_of_metrics
 
         private
 
@@ -19,6 +22,7 @@ module StatsD
 
         def datagrams_by_type_then_key
           datagrams.split.map do |datagram|
+            @pre_aggregation_number_of_metrics += 1
             DogStatsDDatagram.new(datagram)
           end.group_by(&:type).to_h do |type, parsed_datagrams|
             [type, parsed_datagrams.group_by(&:key).to_h]

--- a/lib/statsd/instrument/prometheus/batched_prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/batched_prometheus_sink.rb
@@ -29,7 +29,10 @@ module StatsD
           default_tags:,
           open_timeout:,
           read_timeout:,
-          write_timeout:
+          write_timeout:,
+          seconds_to_sleep:,
+          seconds_between_flushes:,
+          max_fill_ratio:
         )
           dispatcher = PeriodicDispatcher.new(
             nil,
@@ -48,6 +51,9 @@ module StatsD
               read_timeout,
               write_timeout,
             ),
+            seconds_to_sleep,
+            seconds_between_flushes,
+            max_fill_ratio,
           )
           super(
             host,

--- a/lib/statsd/instrument/prometheus/flush_stats.rb
+++ b/lib/statsd/instrument/prometheus/flush_stats.rb
@@ -5,12 +5,14 @@ module StatsD
     module Prometheus
       class FlushStats
         def initialize(datagrams, default_tags, pre_aggregation_number_of_metrics, number_of_requests_attepted,
-          number_of_requests_succeeded)
+          number_of_requests_succeeded, number_of_metrics_dropped_due_to_buffer_full, last_flush_initiated_time)
           @datagrams = datagrams
           @default_tags = default_tags
           @pre_aggregation_number_of_metrics = pre_aggregation_number_of_metrics
           @number_of_requests_attepted = number_of_requests_attepted
           @number_of_requests_succeeded = number_of_requests_succeeded
+          @number_of_metrics_dropped_due_to_buffer_full = number_of_metrics_dropped_due_to_buffer_full
+          @last_flush_initiated_time = last_flush_initiated_time
         end
 
         def run
@@ -23,7 +25,9 @@ module StatsD
           :default_tags,
           :pre_aggregation_number_of_metrics,
           :number_of_requests_attepted,
-          :number_of_requests_succeeded
+          :number_of_requests_succeeded,
+          :number_of_metrics_dropped_due_to_buffer_full,
+          :last_flush_initiated_time
 
         def flush_stats
           [
@@ -55,6 +59,22 @@ module StatsD
               DogStatsDDatagramBuilder.new(default_tags: default_tags).c(
                 "number_of_requests_succeeded_upto_previous_flush.total",
                 number_of_requests_succeeded,
+                nil,
+                nil,
+              ),
+            ),
+            DogStatsDDatagram.new(
+              DogStatsDDatagramBuilder.new(default_tags: default_tags).c(
+                "number_of_metrics_dropped_due_to_buffer_full.total",
+                number_of_metrics_dropped_due_to_buffer_full,
+                nil,
+                nil,
+              ),
+            ),
+            DogStatsDDatagram.new(
+              DogStatsDDatagramBuilder.new(default_tags: default_tags).g(
+                "time_since_last_flush_initiated",
+                (Time.now - last_flush_initiated_time) * 1000,
                 nil,
                 nil,
               ),

--- a/lib/statsd/instrument/prometheus/flush_stats.rb
+++ b/lib/statsd/instrument/prometheus/flush_stats.rb
@@ -4,28 +4,39 @@ module StatsD
   module Instrument
     module Prometheus
       class FlushStats
-        def initialize(datagrams, default_tags)
+        def initialize(datagrams, default_tags, pre_aggregation_number_of_metrics)
           @datagrams = datagrams
           @default_tags = default_tags
+          @pre_aggregation_number_of_metrics = pre_aggregation_number_of_metrics
         end
 
         def run
-          datagrams + [flush_stats]
+          datagrams + flush_stats
         end
 
         private
 
-        attr_reader :datagrams, :default_tags
+        attr_reader :datagrams, :default_tags, :pre_aggregation_number_of_metrics
 
         def flush_stats
-          DogStatsDDatagram.new(
-            DogStatsDDatagramBuilder.new(default_tags: default_tags).g(
-              "metrics_since_last_flush",
-              datagrams.count,
-              nil,
-              nil,
+          [
+            DogStatsDDatagram.new(
+              DogStatsDDatagramBuilder.new(default_tags: default_tags).g(
+                "metrics_since_last_flush",
+                datagrams.count,
+                nil,
+                nil,
+              ),
             ),
-          )
+            DogStatsDDatagram.new(
+              DogStatsDDatagramBuilder.new(default_tags: default_tags).g(
+                "pre_aggregation_number_of_metrics_since_last_flush",
+                pre_aggregation_number_of_metrics,
+                nil,
+                nil,
+              ),
+            ),
+          ]
         end
       end
     end

--- a/lib/statsd/instrument/prometheus/flush_stats.rb
+++ b/lib/statsd/instrument/prometheus/flush_stats.rb
@@ -4,10 +4,13 @@ module StatsD
   module Instrument
     module Prometheus
       class FlushStats
-        def initialize(datagrams, default_tags, pre_aggregation_number_of_metrics)
+        def initialize(datagrams, default_tags, pre_aggregation_number_of_metrics, number_of_requests_attepted,
+          number_of_requests_succeeded)
           @datagrams = datagrams
           @default_tags = default_tags
           @pre_aggregation_number_of_metrics = pre_aggregation_number_of_metrics
+          @number_of_requests_attepted = number_of_requests_attepted
+          @number_of_requests_succeeded = number_of_requests_succeeded
         end
 
         def run
@@ -16,7 +19,11 @@ module StatsD
 
         private
 
-        attr_reader :datagrams, :default_tags, :pre_aggregation_number_of_metrics
+        attr_reader :datagrams,
+          :default_tags,
+          :pre_aggregation_number_of_metrics,
+          :number_of_requests_attepted,
+          :number_of_requests_succeeded
 
         def flush_stats
           [
@@ -32,6 +39,22 @@ module StatsD
               DogStatsDDatagramBuilder.new(default_tags: default_tags).g(
                 "pre_aggregation_number_of_metrics_since_last_flush",
                 pre_aggregation_number_of_metrics,
+                nil,
+                nil,
+              ),
+            ),
+            DogStatsDDatagram.new(
+              DogStatsDDatagramBuilder.new(default_tags: default_tags).c(
+                "number_of_requests_attepted.total",
+                number_of_requests_attepted,
+                nil,
+                nil,
+              ),
+            ),
+            DogStatsDDatagram.new(
+              DogStatsDDatagramBuilder.new(default_tags: default_tags).c(
+                "number_of_requests_succeeded_upto_previous_flush.total",
+                number_of_requests_succeeded,
                 nil,
                 nil,
               ),

--- a/lib/statsd/instrument/prometheus/flush_stats.rb
+++ b/lib/statsd/instrument/prometheus/flush_stats.rb
@@ -4,12 +4,12 @@ module StatsD
   module Instrument
     module Prometheus
       class FlushStats
-        def initialize(datagrams, default_tags, pre_aggregation_number_of_metrics, number_of_requests_attepted,
+        def initialize(datagrams, default_tags, pre_aggregation_number_of_metrics, number_of_requests_attempted,
           number_of_requests_succeeded, number_of_metrics_dropped_due_to_buffer_full, last_flush_initiated_time)
           @datagrams = datagrams
           @default_tags = default_tags
           @pre_aggregation_number_of_metrics = pre_aggregation_number_of_metrics
-          @number_of_requests_attepted = number_of_requests_attepted
+          @number_of_requests_attempted = number_of_requests_attempted
           @number_of_requests_succeeded = number_of_requests_succeeded
           @number_of_metrics_dropped_due_to_buffer_full = number_of_metrics_dropped_due_to_buffer_full
           @last_flush_initiated_time = last_flush_initiated_time
@@ -24,7 +24,7 @@ module StatsD
         attr_reader :datagrams,
           :default_tags,
           :pre_aggregation_number_of_metrics,
-          :number_of_requests_attepted,
+          :number_of_requests_attempted,
           :number_of_requests_succeeded,
           :number_of_metrics_dropped_due_to_buffer_full,
           :last_flush_initiated_time
@@ -49,8 +49,8 @@ module StatsD
             ),
             DogStatsDDatagram.new(
               DogStatsDDatagramBuilder.new(default_tags: default_tags).c(
-                "number_of_requests_attepted.total",
-                number_of_requests_attepted,
+                "number_of_requests_attempted.total",
+                number_of_requests_attempted,
                 nil,
                 nil,
               ),

--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -31,7 +31,7 @@ module StatsD
           :open_timeout,
           :read_timeout,
           :write_timeout,
-          :number_of_requests_attepted,
+          :number_of_requests_attempted,
           :number_of_requests_succeeded,
           :number_of_metrics_dropped_due_to_buffer_full,
           :last_flush_initiated_time
@@ -47,7 +47,7 @@ module StatsD
           @open_timeout = open_timeout
           @read_timeout = read_timeout
           @write_timeout = write_timeout
-          @number_of_requests_attepted = 0
+          @number_of_requests_attempted = 0
           @number_of_requests_succeeded = 0
           @number_of_metrics_dropped_due_to_buffer_full = 0
           @last_flush_initiated_time = Time.now
@@ -56,7 +56,7 @@ module StatsD
         def <<(datagram)
           current_flush_initiated_time = Time.now
           invalidate_socket_and_retry_if_error do
-            @number_of_requests_attepted += 1
+            @number_of_requests_attempted += 1
             response = make_request(datagram)
             if response.code == "201"
               @number_of_requests_succeeded += 1
@@ -83,7 +83,7 @@ module StatsD
             aggregated,
             default_tags,
             aggregator.pre_aggregation_number_of_metrics,
-            number_of_requests_attepted,
+            number_of_requests_attempted,
             number_of_requests_succeeded,
             number_of_metrics_dropped_due_to_buffer_full,
             last_flush_initiated_time,

--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -58,8 +58,13 @@ module StatsD
         private
 
         def request_body(datagram)
-          aggregated = StatsD::Instrument::Prometheus::Aggregator.new(datagram, percentiles).run
-          aggregated_with_flush_stats = StatsD::Instrument::Prometheus::FlushStats.new(aggregated, default_tags).run
+          aggregator = StatsD::Instrument::Prometheus::Aggregator.new(datagram, percentiles)
+          aggregated = aggregator.run
+          aggregated_with_flush_stats = StatsD::Instrument::Prometheus::FlushStats.new(
+            aggregated,
+            default_tags,
+            aggregator.pre_aggregation_number_of_metrics,
+          ).run
           serialized = StatsD::Instrument::Prometheus::Serializer.new(
             aggregated_with_flush_stats,
             application_name,

--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -64,6 +64,10 @@ module StatsD
           self
         end
 
+        def failed_to_push!
+          # @number_of_metrics_dropped_due_to_buffer_full += 1
+        end
+
         private
 
         def request_body(datagram)

--- a/test/helpers/prometheus_helper.rb
+++ b/test/helpers/prometheus_helper.rb
@@ -10,6 +10,9 @@ module PrometheusHelper
       timeseries.labels.entries.each do |label|
         label.value = "" if ["pid", "host"].include?(label.name) # These will vary per run/machine
       end
+      timeseries.samples.entries.each do |sample|
+        sample.value = -1 # Timecop not working for multithreaded stuff
+      end if timeseries.labels.entries.map(&:value).include?("time_since_last_flush_initiated")
     end
     result
   end

--- a/test/prometheus/integration_test.rb
+++ b/test/prometheus/integration_test.rb
@@ -73,6 +73,34 @@ module Prometheus
             ],
             exemplars: [],
           },
+          {
+            labels: [
+              { name: "__meta_applicationname", value: "app-name" },
+              { name: "__meta_subsystem", value: "subsystem" },
+              { name: "host", value: "" },
+              { name: "pid", value: "" },
+              { name: "__name__", value: "number_of_requests_attepted.total" },
+              { name: "env", value: "test" },
+            ],
+            samples: [
+              { value: 1.0, timestamp: -1 },
+            ],
+            exemplars: [],
+          },
+          {
+            labels: [
+              { name: "__meta_applicationname", value: "app-name" },
+              { name: "__meta_subsystem", value: "subsystem" },
+              { name: "host", value: "" },
+              { name: "pid", value: "" },
+              { name: "__name__", value: "number_of_requests_succeeded_upto_previous_flush.total" },
+              { name: "env", value: "test" },
+            ],
+            samples: [
+              { value: 0.0, timestamp: -1 },
+            ],
+            exemplars: [],
+          },
         ],
         metadata: [],
       }

--- a/test/prometheus/integration_test.rb
+++ b/test/prometheus/integration_test.rb
@@ -41,7 +41,7 @@ module Prometheus
               { name: "env", value: "test" },
             ],
             samples: [
-              { value: 1.0, timestamp: -1 },
+              { value: 2.0, timestamp: -1 },
             ],
             exemplars: [],
           },
@@ -59,10 +59,25 @@ module Prometheus
             ],
             exemplars: [],
           },
+          {
+            labels: [
+              { name: "__meta_applicationname", value: "app-name" },
+              { name: "__meta_subsystem", value: "subsystem" },
+              { name: "host", value: "" },
+              { name: "pid", value: "" },
+              { name: "__name__", value: "pre_aggregation_number_of_metrics_since_last_flush" },
+              { name: "env", value: "test" },
+            ],
+            samples: [
+              { value: 2.0, timestamp: -1 },
+            ],
+            exemplars: [],
+          },
         ],
         metadata: [],
       }
       stub_request(:post, TEST_URL).to_return(status: 201)
+      StatsD.increment("counter", tags: { source: "App::Main::Controller", host: "localhost" })
       StatsD.increment("counter", tags: { source: "App::Main::Controller", host: "localhost" })
       StatsD.singleton_client.sink.shutdown
       assert_request_contents(TEST_URL, expected, expected_headers: { "Authorization" => "Bearer abc" })

--- a/test/prometheus/integration_test.rb
+++ b/test/prometheus/integration_test.rb
@@ -64,7 +64,7 @@ module Prometheus
           },
           expected_metric("metrics_since_last_flush", 1.0),
           expected_metric("pre_aggregation_number_of_metrics_since_last_flush", 2.0),
-          expected_metric("number_of_requests_attepted.total", 1.0),
+          expected_metric("number_of_requests_attempted.total", 1.0),
           expected_metric("number_of_requests_succeeded_upto_previous_flush.total", 0.0),
           expected_metric("number_of_metrics_dropped_due_to_buffer_full.total", 0.0),
           expected_metric("time_since_last_flush_initiated", -1),

--- a/test/prometheus/integration_test.rb
+++ b/test/prometheus/integration_test.rb
@@ -27,6 +27,23 @@ module Prometheus
       StatsD.singleton_client = @old_client
     end
 
+    def expected_metric(name, value, additional_labels: [])
+      {
+        labels: [
+          { name: "__meta_applicationname", value: "app-name" },
+          { name: "__meta_subsystem", value: "subsystem" },
+          { name: "host", value: "" },
+          { name: "pid", value: "" },
+          { name: "__name__", value: name },
+          { name: "env", value: "test" },
+        ] + additional_labels,
+        samples: [
+          { value: value, timestamp: -1 },
+        ],
+        exemplars: [],
+      }
+    end
+
     def test_mocked_request
       expected = {
         timeseries: [
@@ -45,62 +62,12 @@ module Prometheus
             ],
             exemplars: [],
           },
-          {
-            labels: [
-              { name: "__meta_applicationname", value: "app-name" },
-              { name: "__meta_subsystem", value: "subsystem" },
-              { name: "host", value: "" },
-              { name: "pid", value: "" },
-              { name: "__name__", value: "metrics_since_last_flush" },
-              { name: "env", value: "test" },
-            ],
-            samples: [
-              { value: 1.0, timestamp: -1 },
-            ],
-            exemplars: [],
-          },
-          {
-            labels: [
-              { name: "__meta_applicationname", value: "app-name" },
-              { name: "__meta_subsystem", value: "subsystem" },
-              { name: "host", value: "" },
-              { name: "pid", value: "" },
-              { name: "__name__", value: "pre_aggregation_number_of_metrics_since_last_flush" },
-              { name: "env", value: "test" },
-            ],
-            samples: [
-              { value: 2.0, timestamp: -1 },
-            ],
-            exemplars: [],
-          },
-          {
-            labels: [
-              { name: "__meta_applicationname", value: "app-name" },
-              { name: "__meta_subsystem", value: "subsystem" },
-              { name: "host", value: "" },
-              { name: "pid", value: "" },
-              { name: "__name__", value: "number_of_requests_attepted.total" },
-              { name: "env", value: "test" },
-            ],
-            samples: [
-              { value: 1.0, timestamp: -1 },
-            ],
-            exemplars: [],
-          },
-          {
-            labels: [
-              { name: "__meta_applicationname", value: "app-name" },
-              { name: "__meta_subsystem", value: "subsystem" },
-              { name: "host", value: "" },
-              { name: "pid", value: "" },
-              { name: "__name__", value: "number_of_requests_succeeded_upto_previous_flush.total" },
-              { name: "env", value: "test" },
-            ],
-            samples: [
-              { value: 0.0, timestamp: -1 },
-            ],
-            exemplars: [],
-          },
+          expected_metric("metrics_since_last_flush", 1.0),
+          expected_metric("pre_aggregation_number_of_metrics_since_last_flush", 2.0),
+          expected_metric("number_of_requests_attepted.total", 1.0),
+          expected_metric("number_of_requests_succeeded_upto_previous_flush.total", 0.0),
+          expected_metric("number_of_metrics_dropped_due_to_buffer_full.total", 0.0),
+          expected_metric("time_since_last_flush_initiated", -1),
         ],
         metadata: [],
       }


### PR DESCRIPTION
*Adds the following stats:*
- Number of metrics before aggregation. This enables us to see how much work our aggregation is doing. I expect significant aggregation is happening, but if not, I'd like to know as it could be impacting perf.
- Number of requests made. This enables us to track exactly how many requests are being made to send metrics to prometheus. When used in conjunction with 👇 , will tell us the rate at which requests are succeeding/failing
- Number of requests succeeded (up to previous flush). This enables us to track exactly how many successful requests have been made to send metrics to prometheus.
- Number of metrics dropped due to buffer full. Will help us understand if we're regularly bumping the max buffer size
- Time since last flush initiated. This will give us the time between flushes, which will help us identify how often we're flushing which could indicate pressure on the buffer (or a low max packet size setting).

*Changes the following behaviour*
- Prometheus metrics won't attempt to send synchronously. Sync sending poses too much risk of impacting application perf.
- Provide configuration options for the batch sending. This will enable us to more rapidly fine-tune our batch sending should we see too much pressure on the buffer.