### PR TITLE
[PLT-93] Make it work for Grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ The following environment variables are supported:
   If your network is properly configured to handle larger packets you may try
   to increase this value for better performance, but most network can't handle
   larger packets.
-- `STATSD_PROMETHEUS_AUTH`:  The API key for the prometheus endpoint. If set, will send batch stats in prometheus-compatible format
+- `STATSD_PROMETHEUS_AUTH`:  The API key (or password for basic auth) for the prometheus endpoint. If set, will send batch stats in prometheus-compatible format
+- `STATSD_PROMETHEUS_BASIC_AUTH_USER`:  The user to use if basic auth is required.
 - `STATSD_PROMETHEUS_PERCENTILES`:  The percentiles that will be calulcated when aggregating timers for prometheus. 95,99 are the default.
 - `STATSD_PROMETHEUS_APPLICATION_NAME`:  The application name that will be included as a tag in all metrics sent to prometheus.
 - `STATSD_PROMETHEUS_SUBSYSTEM`:  The subsystem that will be included as a tag in all metrics sent to prometheus.

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -102,6 +102,10 @@ module StatsD
         env.fetch("STATSD_PROMETHEUS_AUTH", nil)
       end
 
+      def prometheus_basic_auth_user
+        env.fetch("STATSD_PROMETHEUS_BASIC_AUTH_USER", nil)
+      end
+
       def prometheus_application_name
         env.fetch("STATSD_PROMETHEUS_APPLICATION_NAME", nil)
       end
@@ -166,6 +170,7 @@ module StatsD
               seconds_to_sleep: prometheus_seconds_to_sleep,
               seconds_between_flushes: prometheus_seconds_between_flushes,
               max_fill_ratio: prometheus_max_fill_ratio,
+              basic_auth_user: prometheus_basic_auth_user,
             )
           elsif statsd_batching?
             StatsD::Instrument::BatchedUDPSink.for_addr(

--- a/lib/statsd/instrument/prometheus/batched_prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/batched_prometheus_sink.rb
@@ -32,7 +32,8 @@ module StatsD
           write_timeout:,
           seconds_to_sleep:,
           seconds_between_flushes:,
-          max_fill_ratio:
+          max_fill_ratio:,
+          basic_auth_user:
         )
           dispatcher = PeriodicDispatcher.new(
             nil,
@@ -50,6 +51,7 @@ module StatsD
               open_timeout,
               read_timeout,
               write_timeout,
+              basic_auth_user,
             ),
             seconds_to_sleep,
             seconds_between_flushes,

--- a/lib/statsd/instrument/prometheus/flush_stats.rb
+++ b/lib/statsd/instrument/prometheus/flush_stats.rb
@@ -5,7 +5,7 @@ module StatsD
     module Prometheus
       class FlushStats
         def initialize(datagrams, default_tags, pre_aggregation_number_of_metrics, number_of_requests_attempted,
-          number_of_requests_succeeded, number_of_metrics_dropped_due_to_buffer_full, last_flush_initiated_time)
+          number_of_requests_succeeded, number_of_metrics_dropped_due_to_buffer_full, last_flush_initiated_time, number_of_metrics_dropped_due_to_parsing_failure)
           @datagrams = datagrams
           @default_tags = default_tags
           @pre_aggregation_number_of_metrics = pre_aggregation_number_of_metrics
@@ -13,6 +13,7 @@ module StatsD
           @number_of_requests_succeeded = number_of_requests_succeeded
           @number_of_metrics_dropped_due_to_buffer_full = number_of_metrics_dropped_due_to_buffer_full
           @last_flush_initiated_time = last_flush_initiated_time
+          @number_of_metrics_dropped_due_to_parsing_failure = number_of_metrics_dropped_due_to_parsing_failure
         end
 
         def run
@@ -27,7 +28,8 @@ module StatsD
           :number_of_requests_attempted,
           :number_of_requests_succeeded,
           :number_of_metrics_dropped_due_to_buffer_full,
-          :last_flush_initiated_time
+          :last_flush_initiated_time,
+          :number_of_metrics_dropped_due_to_parsing_failure
 
         def flush_stats
           [
@@ -75,6 +77,14 @@ module StatsD
               DogStatsDDatagramBuilder.new(default_tags: default_tags).g(
                 "time_since_last_flush_initiated",
                 (Time.now - last_flush_initiated_time) * 1000,
+                nil,
+                nil,
+              ),
+            ),
+            DogStatsDDatagram.new(
+              DogStatsDDatagramBuilder.new(default_tags: default_tags).c(
+                "number_of_metrics_dropped_due_to_parsing_failure.total",
+                number_of_metrics_dropped_due_to_parsing_failure,
                 nil,
                 nil,
               ),

--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -87,6 +87,7 @@ module StatsD
             number_of_requests_succeeded,
             number_of_metrics_dropped_due_to_buffer_full,
             last_flush_initiated_time,
+            aggregator.number_of_metrics_failed_to_parse,
           ).run
           serialized = StatsD::Instrument::Prometheus::Serializer.new(
             aggregated_with_flush_stats,

--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -34,9 +34,10 @@ module StatsD
           :number_of_requests_attempted,
           :number_of_requests_succeeded,
           :number_of_metrics_dropped_due_to_buffer_full,
-          :last_flush_initiated_time
+          :last_flush_initiated_time,
+          :basic_auth_user
 
-        def initialize(addr, auth_key, percentiles, application_name, subsystem, default_tags, open_timeout, read_timeout, write_timeout) # rubocop:disable Lint/MissingSuper
+        def initialize(addr, auth_key, percentiles, application_name, subsystem, default_tags, open_timeout, read_timeout, write_timeout, basic_auth_user) # rubocop:disable Lint/MissingSuper
           ObjectSpace.define_finalizer(self, FINALIZER)
           @uri = URI(addr)
           @auth_key = auth_key
@@ -51,6 +52,7 @@ module StatsD
           @number_of_requests_succeeded = 0
           @number_of_metrics_dropped_due_to_buffer_full = 0
           @last_flush_initiated_time = Time.now
+          @basic_auth_user = basic_auth_user
         end
 
         def <<(datagram)
@@ -58,7 +60,7 @@ module StatsD
           invalidate_socket_and_retry_if_error do
             @number_of_requests_attempted += 1
             response = make_request(datagram)
-            if response.code == "201"
+            if ["201", "200"].include?(response.code)
               @number_of_requests_succeeded += 1
             else
               StatsD.logger.warn do
@@ -99,7 +101,11 @@ module StatsD
 
         def make_request(datagram)
           request = Net::HTTP::Post.new(uri.request_uri)
-          request["Authorization"] = "Bearer #{auth_key}"
+          if basic_auth_user
+            request.basic_auth(basic_auth_user, auth_key)
+          else
+            request["Authorization"] = "Bearer #{auth_key}"
+          end
           request.body = request_body(datagram)
           socket.request(request)
         end

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -55,7 +55,7 @@ module StatsD
         retried = false
         begin
           yield
-        rescue SocketError, IOError, SystemCallError => error
+        rescue SocketError, IOError, SystemCallError, Net::OpenTimeout => error
           StatsD.logger.debug do
             "[StatsD::Instrument::UDPSink] Resetting connection because of #{error.class}: #{error.message}"
           end

--- a/test/prometheus/aggregator_test.rb
+++ b/test/prometheus/aggregator_test.rb
@@ -15,6 +15,12 @@ module Prometheus
       assert_equal(14, aggregator.run.last.value)
     end
 
+    def test_run_with_failed_parse
+      aggregator = described_class.new("bar::1|c\nfoo:10|c\nfoo:1|c\nfoo:1|c\nfoo:2|c")
+      assert_equal(1, aggregator.run.length)
+      assert_equal(14, aggregator.run.last.value)
+    end
+
     def test_run_with_last_value
       aggregator = described_class.new("foo:10|g\nfoo:1|g\nfoo:1|g\nfoo:2|g")
       assert_equal(1, aggregator.run.length)


### PR DESCRIPTION
Includes the following changes to make the implementation work on Grafana Cloud:
* Grafana uses basic auth, so added this as an authentication mechanism
* Fixed an issue where Cleo generates some dynic metric names that are invalid - we drop them, but keep a counter of how many times this is happening
* Fixed an issue where we weren't retrying on connection timeouts when we do want to retry here