### PR TITLE
[PLT-XXX] Do not call `super` until after instance vars are set

### DIFF
--- a/lib/statsd/instrument/prometheus/periodic_dispatcher.rb
+++ b/lib/statsd/instrument/prometheus/periodic_dispatcher.rb
@@ -10,10 +10,10 @@ module StatsD
       class PeriodicDispatcher < ::StatsD::Instrument::Dispatcher
         def initialize(host, port, buffer_capacity, thread_priority, max_packet_size, sink, seconds_to_sleep,
           seconds_between_flushes, max_fill_ratio)
-          super(host, port, buffer_capacity, thread_priority, max_packet_size, sink)
           @seconds_to_sleep = seconds_to_sleep
           @seconds_between_flushes = seconds_between_flushes
           @max_fill_ratio = max_fill_ratio
+          super(host, port, buffer_capacity, thread_priority, max_packet_size, sink)
         end
 
         def <<(datagram)


### PR DESCRIPTION
This ensures that instance vars are set before calling `super` in the periodic dispatcher.

This is important because the dispatcher thread is started in the initializer, and if the thread is started before the variables are set, then it will not be able to run properly.