### PR TITLE
[PLT-158] Ability to publish histogram buckets

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -51,3 +51,6 @@ StatsD/MeasureAsDistArgument:
 
 StatsD/MetricPrefixArgument:
   Enabled: true
+
+Layout/LineLength:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following environment variables are supported:
 - `STATSD_PROMETHEUS_AUTH`:  The API key (or password for basic auth) for the prometheus endpoint. If set, will send batch stats in prometheus-compatible format
 - `STATSD_PROMETHEUS_BASIC_AUTH_USER`:  The user to use if basic auth is required.
 - `STATSD_PROMETHEUS_PERCENTILES`:  The percentiles that will be calulcated when aggregating timers for prometheus. 95,99 are the default.
+- `STATSD_PROMETHEUS_HISTOGRAMS`:  The histogram buckets that will be used when aggregating timers for prometheus. Buckets are expected to be defined in milliseconds. 5,10,25,50,75,100,250,500,750,1000,2500,5000,7500,10000 are the default buckets.
 - `STATSD_PROMETHEUS_APPLICATION_NAME`:  The application name that will be included as a tag in all metrics sent to prometheus.
 - `STATSD_PROMETHEUS_SUBSYSTEM`:  The subsystem that will be included as a tag in all metrics sent to prometheus.
 - `STATSD_PROMETHEUS_OPEN_TIMEOUT`:  The timeout for connecting to the Prometheus backend (default is 2s).

--- a/lib/statsd/instrument.rb
+++ b/lib/statsd/instrument.rb
@@ -359,7 +359,7 @@ module StatsD
     # @!method distribution(name, value = nil, sample_rate: nil, tags: nil, &block)
     #   (see StatsD::Instrument::Client#distribution)
     #
-    # @!method event(title, text, tags: nil, hostname: nil, timestamp: nil, aggregation_key: nil, priority: nil, source_type_name: nil, alert_type: nil) # rubocop:disable Layout/LineLength
+    # @!method event(title, text, tags: nil, hostname: nil, timestamp: nil, aggregation_key: nil, priority: nil, source_type_name: nil, alert_type: nil)
     #   (see StatsD::Instrument::Client#event)
     #
     # @!method service_check(name, status, tags: nil, hostname: nil, timestamp: nil, message: nil)

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -118,6 +118,10 @@ module StatsD
         env.fetch("STATSD_PROMETHEUS_PERCENTILES", "95,99").split(",").map(&:to_i)
       end
 
+      def prometheus_histograms
+        env.fetch("STATSD_PROMETHEUS_HISTOGRAMS", "5,10,25,50,75,100,250,500,750,1000,2500,5000,7500,10000").split(",").map(&:to_i)
+      end
+
       def statsd_max_packet_size
         default_statsd_max_packet_size = prometheus? ? StatsD::Instrument::Prometheus::BatchedPrometheusSink::DEFAULT_MAX_PACKET_SIZE : StatsD::Instrument::BatchedUDPSink::DEFAULT_MAX_PACKET_SIZE
         Float(env.fetch("STATSD_MAX_PACKET_SIZE", default_statsd_max_packet_size))
@@ -171,6 +175,7 @@ module StatsD
               seconds_between_flushes: prometheus_seconds_between_flushes,
               max_fill_ratio: prometheus_max_fill_ratio,
               basic_auth_user: prometheus_basic_auth_user,
+              histograms: prometheus_histograms,
             )
           elsif statsd_batching?
             StatsD::Instrument::BatchedUDPSink.for_addr(

--- a/lib/statsd/instrument/prometheus/aggregator.rb
+++ b/lib/statsd/instrument/prometheus/aggregator.rb
@@ -4,9 +4,10 @@ module StatsD
   module Instrument
     module Prometheus
       class Aggregator
-        def initialize(datagrams, percentiles = nil)
+        def initialize(datagrams, percentiles = nil, histograms = nil)
           @datagrams = datagrams
           @percentiles = percentiles
+          @histograms = histograms
           @pre_aggregation_number_of_metrics = 0
           @number_of_metrics_failed_to_parse = 0
         end
@@ -19,7 +20,7 @@ module StatsD
 
         private
 
-        attr_reader :datagrams, :percentiles
+        attr_reader :datagrams, :percentiles, :histograms
 
         def datagrams_by_type_then_key
           datagrams.split.map do |datagram|
@@ -33,7 +34,7 @@ module StatsD
         def aggregated_datagrams
           datagrams_by_type_then_key.flat_map do |type, datagrams_by_key|
             datagrams_by_key.flat_map do |_, datagrams_for_key|
-              aggregation_class_for_type(type).new(datagrams_for_key, percentiles: percentiles).aggregate
+              aggregation_class_for_type(type).new(datagrams_for_key, percentiles: percentiles, histograms: histograms).aggregate
             end
           end
         end

--- a/lib/statsd/instrument/prometheus/aggregators/timing.rb
+++ b/lib/statsd/instrument/prometheus/aggregators/timing.rb
@@ -13,20 +13,13 @@ module StatsD
             values = datagrams.map(&:value).sort
             count = values.length
             min = values.first
-            max = values.last
 
             cumulative_values = [min]
-            cumulative_sum_squares_values = [min * min]
             for i in 1..(count - 1) do # rubocop:disable Style/for
               cumulative_values.push(values[i] + cumulative_values[i - 1])
-              cumulative_sum_squares_values.push((values[i] * values[i]) + cumulative_sum_squares_values[i - 1])
             end
 
             sum = min
-            sum_squares = min * min
-            mean = min
-            threshold_boundary = max
-
             percentiles.each do |percentile_threshold|
               count_within_percentile_threshold = count.to_f
 
@@ -34,50 +27,22 @@ module StatsD
                 count_within_percentile_threshold = (percentile_threshold.abs / 100.0 * count).round
                 next if count_within_percentile_threshold == 0
 
-                if percentile_threshold > 0
-                  threshold_boundary = values[count_within_percentile_threshold - 1]
-                  sum = cumulative_values[count_within_percentile_threshold - 1]
-                  sum_squares = cumulative_sum_squares_values[count_within_percentile_threshold - 1]
+                sum = if percentile_threshold > 0
+                  cumulative_values[count_within_percentile_threshold - 1]
                 else
-                  threshold_boundary = values[count - count_within_percentile_threshold]
-                  sum = cumulative_values[count - 1] - cumulative_values[count - count_within_percentile_threshold - 1]
-                  sum_squares = cumulative_sum_squares_values[count - 1] - cumulative_sum_squares_values[count - count_within_percentile_threshold - 1]
+                  cumulative_values[count - 1] - cumulative_values[count - count_within_percentile_threshold - 1]
                 end
-                mean = sum / count_within_percentile_threshold
               end
 
               clean_percentile_threshold = percentile_threshold.to_s
               clean_percentile_threshold = clean_percentile_threshold.gsub(".", "_").gsub("-", "top")
               current_timer_count_data["count_" + clean_percentile_threshold] = count_within_percentile_threshold.to_i
-              current_timer_data["mean_" + clean_percentile_threshold] = mean
-              current_timer_data[(percentile_threshold > 0 ? "upper_" : "lower_") + clean_percentile_threshold] =
-                threshold_boundary
               current_timer_data["sum_" + clean_percentile_threshold] = sum
-              current_timer_data["sum_squares_" + clean_percentile_threshold] = sum_squares
             end
 
             sum = cumulative_values[count - 1]
-            sum_squares = cumulative_sum_squares_values[count - 1]
-            mean = sum / count.to_f
-
-            sum_of_diffs = 0
-            for i in 0..(count - 1) do # rubocop:disable Style/for
-              sum_of_diffs += (values[i] - mean) * (values[i] - mean)
-            end
-
-            mid = (count / 2.0).floor
-            median = count % 2 ? values[mid] : (values[mid - 1] + values[mid]) / 2.0
-
-            stddev = Math.sqrt(sum_of_diffs / count.to_f)
-            current_timer_data["std"] = stddev
-            current_timer_data["upper"] = max
-            current_timer_data["lower"] = min
             current_timer_count_data["count"] = count.to_i
-            # current_timer_data["count_ps"] = count / (flushInterval / 1000.0)
             current_timer_data["sum"] = sum
-            current_timer_data["sum_squares"] = sum_squares
-            current_timer_data["mean"] = mean
-            current_timer_data["median"] = median
 
             last_datagram = datagrams.last
             output = current_timer_data.map do |name, value|

--- a/lib/statsd/instrument/prometheus/batched_prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/batched_prometheus_sink.rb
@@ -33,7 +33,8 @@ module StatsD
           seconds_to_sleep:,
           seconds_between_flushes:,
           max_fill_ratio:,
-          basic_auth_user:
+          basic_auth_user:,
+          histograms:
         )
           dispatcher = PeriodicDispatcher.new(
             nil,
@@ -52,6 +53,7 @@ module StatsD
               read_timeout,
               write_timeout,
               basic_auth_user,
+              histograms,
             ),
             seconds_to_sleep,
             seconds_between_flushes,

--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -35,9 +35,10 @@ module StatsD
           :number_of_requests_succeeded,
           :number_of_metrics_dropped_due_to_buffer_full,
           :last_flush_initiated_time,
-          :basic_auth_user
+          :basic_auth_user,
+          :histograms
 
-        def initialize(addr, auth_key, percentiles, application_name, subsystem, default_tags, open_timeout, read_timeout, write_timeout, basic_auth_user) # rubocop:disable Lint/MissingSuper
+        def initialize(addr, auth_key, percentiles, application_name, subsystem, default_tags, open_timeout, read_timeout, write_timeout, basic_auth_user, histograms) # rubocop:disable Lint/MissingSuper
           ObjectSpace.define_finalizer(self, FINALIZER)
           @uri = URI(addr)
           @auth_key = auth_key
@@ -53,6 +54,7 @@ module StatsD
           @number_of_metrics_dropped_due_to_buffer_full = 0
           @last_flush_initiated_time = Time.now
           @basic_auth_user = basic_auth_user
+          @histograms = histograms
         end
 
         def <<(datagram)
@@ -79,7 +81,7 @@ module StatsD
         private
 
         def request_body(datagram)
-          aggregator = StatsD::Instrument::Prometheus::Aggregator.new(datagram, percentiles)
+          aggregator = StatsD::Instrument::Prometheus::Aggregator.new(datagram, percentiles, histograms)
           aggregated = aggregator.run
           aggregated_with_flush_stats = StatsD::Instrument::Prometheus::FlushStats.new(
             aggregated,

--- a/test/prometheus/aggregator_test.rb
+++ b/test/prometheus/aggregator_test.rb
@@ -56,6 +56,22 @@ module Prometheus
       assert_equal(expected, actual.map(&:source))
     end
 
+    def test_run_with_timer_and_percentiles_one_value
+      values = [5]
+      aggregator = described_class.new(values.map { |value| "foo:#{value}|ms" }.join("\n"), [90, 95])
+      assert_equal(6, aggregator.run.length)
+      actual = aggregator.run
+      expected = [
+        "foo.sum_90:5.0|ms",
+        "foo.sum_95:5.0|ms",
+        "foo.sum:5.0|ms",
+        "foo.count_90:1|c",
+        "foo.count_95:1|c",
+        "foo.count:1|c",
+      ]
+      assert_equal(expected, actual.map(&:source))
+    end
+
     def test_run_with_timer
       values = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95]
       aggregator = described_class.new(values.map { |value| "foo:#{value}|ms" }.join("\n"), [])

--- a/test/prometheus/aggregator_test.rb
+++ b/test/prometheus/aggregator_test.rb
@@ -43,24 +43,12 @@ module Prometheus
     def test_run_with_timer_and_percentiles
       values = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95]
       aggregator = described_class.new(values.map { |value| "foo:#{value}|ms" }.join("\n"), [90, 95])
-      assert_equal(18, aggregator.run.length)
+      assert_equal(6, aggregator.run.length)
       actual = aggregator.run
       expected = [
-        "foo.mean_90:42.5|ms",
-        "foo.upper_90:85.0|ms",
         "foo.sum_90:765.0|ms",
-        "foo.sum_squares_90:44625.0|ms",
-        "foo.mean_95:45.0|ms",
-        "foo.upper_95:90.0|ms",
         "foo.sum_95:855.0|ms",
-        "foo.sum_squares_95:52725.0|ms",
-        "foo.std:28.83140648667699|ms",
-        "foo.upper:95.0|ms",
-        "foo.lower:0.0|ms",
         "foo.sum:950.0|ms",
-        "foo.sum_squares:61750.0|ms",
-        "foo.mean:47.5|ms",
-        "foo.median:50.0|ms",
         "foo.count_90:18|c",
         "foo.count_95:19|c",
         "foo.count:20|c",
@@ -71,16 +59,10 @@ module Prometheus
     def test_run_with_timer
       values = [0, 5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60, 65, 70, 75, 80, 85, 90, 95]
       aggregator = described_class.new(values.map { |value| "foo:#{value}|ms" }.join("\n"), [])
-      assert_equal(8, aggregator.run.length)
+      assert_equal(2, aggregator.run.length)
       actual = aggregator.run
       expected = [
-        "foo.std:28.83140648667699|ms",
-        "foo.upper:95.0|ms",
-        "foo.lower:0.0|ms",
         "foo.sum:950.0|ms",
-        "foo.sum_squares:61750.0|ms",
-        "foo.mean:47.5|ms",
-        "foo.median:50.0|ms",
         "foo.count:20|c",
       ]
       assert_equal(expected, actual.map(&:source))


### PR DESCRIPTION
Includes the following:
* [Remove unnecessary timing metrics](https://github.com/meetcleo/statsd-instrument/commit/679a627e2470fbaa16b23e2fde2373cbd504c48d)
* [Refactor timing calculations](https://github.com/meetcleo/statsd-instrument/commit/b2a14797d0f47f4464bef9045503e66842a30b2a)
* [Add histogram option for timings](https://github.com/meetcleo/statsd-instrument/commit/0593d168a67d59c1f2858f50b05b1ae6482fee22)