### PR TITLE
[PLT-XXX] Improve tag writing

### DIFF
--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -6,6 +6,7 @@ module StatsD
     #   to become the new default in the next major release of this library.
     class DatagramBuilder
       SINGLE_COLON_REGEXP = /\b:\b/.freeze
+      INVALID_TAG_CHARS_REGEXP = /[|,\s]/.freeze
       REPLACEMENT_CHAR = "_"
       class << self
         def unsupported_datagram_types(*types)
@@ -73,11 +74,7 @@ module StatsD
         return [] unless tags
 
         tags = tags.map { |k, v| "#{k.to_s.gsub(SINGLE_COLON_REGEXP, REPLACEMENT_CHAR)}:#{v.to_s.gsub(SINGLE_COLON_REGEXP, REPLACEMENT_CHAR)}" } if tags.is_a?(Hash)
-
-        # Fast path when no string replacement is needed
-        return tags unless tags.any? { |tag| /[|, ]/.match?(tag) }
-
-        tags.map { |tag| tag.tr("|, ", REPLACEMENT_CHAR) }
+        tags.map { |tag| tag.to_s.gsub(INVALID_TAG_CHARS_REGEXP, REPLACEMENT_CHAR) }
       end
 
       # Utility function to remove invalid characters from a StatsD metric name

--- a/lib/statsd/instrument/datagram_builder.rb
+++ b/lib/statsd/instrument/datagram_builder.rb
@@ -5,6 +5,8 @@ module StatsD
     # @note This class is part of the new Client implementation that is intended
     #   to become the new default in the next major release of this library.
     class DatagramBuilder
+      SINGLE_COLON_REGEXP = /\b:\b/.freeze
+      REPLACEMENT_CHAR = "_"
       class << self
         def unsupported_datagram_types(*types)
           types.each do |type|
@@ -70,12 +72,12 @@ module StatsD
       def normalize_tags(tags)
         return [] unless tags
 
-        tags = tags.map { |k, v| "#{k}:#{v}" } if tags.is_a?(Hash)
+        tags = tags.map { |k, v| "#{k.to_s.gsub(SINGLE_COLON_REGEXP, REPLACEMENT_CHAR)}:#{v.to_s.gsub(SINGLE_COLON_REGEXP, REPLACEMENT_CHAR)}" } if tags.is_a?(Hash)
 
         # Fast path when no string replacement is needed
-        return tags unless tags.any? { |tag| /[|,]/.match?(tag) }
+        return tags unless tags.any? { |tag| /[|, ]/.match?(tag) }
 
-        tags.map { |tag| tag.tr("|,", "") }
+        tags.map { |tag| tag.tr("|, ", REPLACEMENT_CHAR) }
       end
 
       # Utility function to remove invalid characters from a StatsD metric name
@@ -83,7 +85,7 @@ module StatsD
         # Fast path when no normalization is needed to avoid copying the string
         return name unless /[:|@]/.match?(name)
 
-        name.tr(":|@", "_")
+        name.tr(":|@", REPLACEMENT_CHAR)
       end
 
       def generate_generic_datagram(name, value, type, sample_rate, tags)

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -196,9 +196,9 @@ class ClientTest < Minitest::Test
       client.increment("bar", tags: ["th|ird_#,tag"])
     end
 
-    assert_includes(datagrams.first.tags, "first_tag:first_value")
-    assert_includes(datagrams.first.tags, "second_tag:second_value")
-    assert_includes(datagrams.first.tags, "third_#tag")
+    assert_includes(datagrams.first.tags, "first_tag:f_irst_value")
+    assert_includes(datagrams.first.tags, "second_tag:sec_ond_value")
+    assert_includes(datagrams.first.tags, "th_ird_#_tag")
   end
 
   def test_sampling

--- a/test/datagram_builder_test.rb
+++ b/test/datagram_builder_test.rb
@@ -15,11 +15,15 @@ class DatagramBuilderTest < Minitest::Test
   end
 
   def test_normalize_unsupported_tag_names
-    assert_equal(["ign#ored"], @datagram_builder.send(:normalize_tags, ["ign#o|re,d"]))
+    assert_equal(["ign#o_re_d"], @datagram_builder.send(:normalize_tags, ["ign#o|re,d"]))
     # NOTE: how this is interpreted by the backend is undefined.
     # We rely on the user to not do stuff like this if they don't want to be surprised.
     # We do not want to take the performance hit of normalizing this.
     assert_equal(["lol::class:omg::lol"], @datagram_builder.send(:normalize_tags, "lol::class" => "omg::lol"))
+    # Funnily enough, double colons are fine, but single colons break things
+    assert_equal(["lol_class:omg_lol"], @datagram_builder.send(:normalize_tags, "lol:class" => "omg:lol"))
+    # Spaces also break things
+    assert_equal(["lol_class:omg_lol"], @datagram_builder.send(:normalize_tags, "lol class" => "omg lol"))
   end
 
   def test_normalize_tags_converts_hash_to_array
@@ -113,6 +117,6 @@ class DatagramBuilderTest < Minitest::Test
     # Default tags are also normalized
     datagram_builder = StatsD::Instrument::DatagramBuilder.new(default_tags: ["f,o|o"])
     datagram = datagram_builder.c("bar", 1, nil, nil)
-    assert_equal("bar:1|c|#foo", datagram)
+    assert_equal("bar:1|c|#f_o_o", datagram)
   end
 end

--- a/test/dogstatsd_datagram_builder_test.rb
+++ b/test/dogstatsd_datagram_builder_test.rb
@@ -29,7 +29,7 @@ class DogStatsDDatagramBuilderTest < Minitest::Test
       tags: { foo: "bar|baz" },
       message: "blah",
     )
-    assert_equal("_sc|service|1|h:localhost|d:1569817332|#foo:barbaz|m:blah", datagram)
+    assert_equal("_sc|service|1|h:localhost|d:1569817332|#foo:bar_baz|m:blah", datagram)
 
     parsed_datagram = StatsD::Instrument::DogStatsDDatagramBuilder.datagram_class.new(datagram)
     assert_equal(:_sc, parsed_datagram.type)
@@ -37,7 +37,7 @@ class DogStatsDDatagramBuilderTest < Minitest::Test
     assert_equal(1, parsed_datagram.value)
     assert_equal("localhost", parsed_datagram.hostname)
     assert_equal(Time.parse("2019-09-30T04:22:12Z"), parsed_datagram.timestamp)
-    assert_equal(["foo:barbaz"], parsed_datagram.tags)
+    assert_equal(["foo:bar_baz"], parsed_datagram.tags)
     assert_equal("blah", parsed_datagram.message)
   end
 
@@ -65,7 +65,7 @@ class DogStatsDDatagramBuilderTest < Minitest::Test
     )
     assert_equal(
       '_e{7,13}:testing|with\\nnewline|h:localhost|d:1569817332|k:my-key|' \
-        "p:low|s:source|t:success|#foo:barbaz",
+        "p:low|s:source|t:success|#foo:bar_baz",
       datagram,
     )
 
@@ -75,7 +75,7 @@ class DogStatsDDatagramBuilderTest < Minitest::Test
     assert_equal("with\nnewline", parsed_datagram.value)
     assert_equal("localhost", parsed_datagram.hostname)
     assert_equal(Time.parse("2019-09-30T04:22:12Z"), parsed_datagram.timestamp)
-    assert_equal(["foo:barbaz"], parsed_datagram.tags)
+    assert_equal(["foo:bar_baz"], parsed_datagram.tags)
     assert_equal("my-key", parsed_datagram.aggregation_key)
     assert_equal("low", parsed_datagram.priority)
     assert_equal("source", parsed_datagram.source_type_name)


### PR DESCRIPTION
This improves tag writing such that written tags can be re-parsed with the existing tag parsing logic. There were two cases where we were able to write tags that could not be parsed:
1. When the tag had a single colon
2. When the tag contained a space

This will reduce the amount of unparseable metrics we're writing, which will reduce the amount of metrics we're currently losing due to parsing failures.
<img width="870" alt="Screenshot 2024-02-05 at 15 24 43" src="https://github.com/meetcleo/statsd-instrument/assets/1008898/3d0adfff-85cb-48b9-90f0-6767c397bfae">

From: https://cleo.app.coralogix.us/#/dashboards/MzXT3l2IP4torRe531Nck