### PR TITLE
[PLT-515] Add worker_index label to prometheus metrics

### DIFF
--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -127,7 +127,7 @@ module StatsD
       end
 
       def prometheus_percentiles
-        env.fetch("STATSD_PROMETHEUS_PERCENTILES", "95,99").split(",").map(&:to_i)
+        env.fetch("STATSD_PROMETHEUS_PERCENTILES", "").split(",").map(&:to_i)
       end
 
       def prometheus_histograms

--- a/lib/statsd/instrument/environment.rb
+++ b/lib/statsd/instrument/environment.rb
@@ -102,6 +102,10 @@ module StatsD
         env.fetch("DYNO", "unknown.0")
       end
 
+      def worker_index
+        env.fetch("WORKER_INDEX", "0")
+      end
+
       def prometheus?
         prometheus_auth != nil
       end
@@ -185,6 +189,7 @@ module StatsD
               basic_auth_user: prometheus_basic_auth_user,
               histograms: prometheus_histograms,
               dyno_number: dyno_number,
+              worker_index: worker_index,
             )
           elsif statsd_batching?
             StatsD::Instrument::BatchedUDPSink.for_addr(

--- a/lib/statsd/instrument/prometheus/batched_prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/batched_prometheus_sink.rb
@@ -35,7 +35,8 @@ module StatsD
           max_fill_ratio:,
           basic_auth_user:,
           histograms:,
-          dyno_number:
+          dyno_number:,
+          worker_index:
         )
           dispatcher = PeriodicDispatcher.new(
             nil,
@@ -56,6 +57,7 @@ module StatsD
               basic_auth_user,
               histograms,
               dyno_number,
+              worker_index,
             ),
             seconds_to_sleep,
             seconds_between_flushes,

--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -37,9 +37,10 @@ module StatsD
           :last_flush_initiated_time,
           :basic_auth_user,
           :histograms,
-          :dyno_number
+          :dyno_number,
+          :worker_index
 
-        def initialize(addr, auth_key, percentiles, application_name, subsystem, default_tags, open_timeout, read_timeout, write_timeout, basic_auth_user, histograms, dyno_number) # rubocop:disable Lint/MissingSuper
+        def initialize(addr, auth_key, percentiles, application_name, subsystem, default_tags, open_timeout, read_timeout, write_timeout, basic_auth_user, histograms, dyno_number, worker_index) # rubocop:disable Lint/MissingSuper
           ObjectSpace.define_finalizer(self, FINALIZER)
           @uri = URI(addr)
           @auth_key = auth_key
@@ -57,6 +58,7 @@ module StatsD
           @basic_auth_user = basic_auth_user
           @histograms = histograms
           @dyno_number = dyno_number
+          @worker_index = worker_index
         end
 
         def <<(datagram)
@@ -100,6 +102,7 @@ module StatsD
             application_name,
             subsystem,
             dyno_number,
+            worker_index,
           ).run
           Snappy.deflate(serialized)
         end

--- a/lib/statsd/instrument/prometheus/serializer.rb
+++ b/lib/statsd/instrument/prometheus/serializer.rb
@@ -8,10 +8,11 @@ module StatsD
         LABEL_EXTRACTOR = /^(?<name>[^\:]+)\:(?<value>.+)$/
         INVALID_NAME_CHARACTERS = /[^a-zA-Z0-9:_]/
 
-        def initialize(datagrams, application_name, subsystem, dyno_number)
+        def initialize(datagrams, application_name, subsystem, dyno_number, worker_index)
           @datagrams = datagrams
           @current_time_ms = (Time.now.to_f * 1000).to_i
           @dyno_number = dyno_number
+          @worker_index = worker_index
           @application_name = application_name
           @subsystem = subsystem
         end
@@ -28,7 +29,7 @@ module StatsD
 
         private
 
-        attr_reader :datagrams, :current_time_ms, :dyno_number, :application_name, :subsystem
+        attr_reader :datagrams, :current_time_ms, :dyno_number, :worker_index, :application_name, :subsystem
 
         def timeseries
           datagrams.map do |datagram|
@@ -46,6 +47,7 @@ module StatsD
             labels["__meta_subsystem"] =
               ::Prometheus::Label.new(name: "__meta_subsystem", value: subsystem) if subsystem
             labels["dyno_number"] = ::Prometheus::Label.new(name: "dyno_number", value: dyno_number) if dyno_number
+            labels["worker_index"] = ::Prometheus::Label.new(name: "worker_index", value: worker_index) if worker_index
           end
         end
 

--- a/test/prometheus/integration_test.rb
+++ b/test/prometheus/integration_test.rb
@@ -18,6 +18,7 @@ module Prometheus
         "STATSD_PROMETHEUS_APPLICATION_NAME" => "app-name",
         "STATSD_PROMETHEUS_SUBSYSTEM" => "subsystem",
         "DYNO" => "web.1",
+        "WORKER_INDEX" => "0",
       )
 
       @old_client = StatsD.singleton_client
@@ -34,6 +35,7 @@ module Prometheus
           { name: "__meta_applicationname", value: "app-name" },
           { name: "__meta_subsystem", value: "subsystem" },
           { name: "dyno_number", value: "1" },
+          { name: "worker_index", value: "0" },
           { name: "__name__", value: name },
           { name: "env", value: "test" },
         ] + additional_labels,
@@ -52,6 +54,7 @@ module Prometheus
               { name: "__meta_applicationname", value: "app-name" },
               { name: "__meta_subsystem", value: "subsystem" },
               { name: "dyno_number", value: "1" },
+              { name: "worker_index", value: "0" },
               { name: "__name__", value: "counter_total" },
               { name: "source", value: "App::Main::Controller" },
               { name: "env", value: "test" },
@@ -66,6 +69,7 @@ module Prometheus
               { name: "__meta_applicationname", value: "app-name" },
               { name: "__meta_subsystem", value: "subsystem" },
               { name: "dyno_number", value: "1" },
+              { name: "worker_index", value: "0" },
               { name: "__name__", value: "will_fail_total" },
               { name: "source", value: "App::Main::Controller" },
               { name: "env", value: "test" },
@@ -86,10 +90,10 @@ module Prometheus
         metadata: [],
       }
       stub_request(:post, TEST_URL).to_return(status: 201)
-      StatsD.increment("counter", tags: { source: "App::Main::Controller", dyno_number: "1" })
-      StatsD.increment("counter", tags: { source: "App::Main::Controller", dyno_number: "1" })
+      StatsD.increment("counter", tags: { source: "App::Main::Controller", dyno_number: "1", worker_index: "0" })
+      StatsD.increment("counter", tags: { source: "App::Main::Controller", dyno_number: "1", worker_index: "0" })
       # Will treat the newline as its own metric that will fail to parse
-      StatsD.increment(":\nwill_fail", tags: { source: "App::Main::Controller", dyno_number: "1" })
+      StatsD.increment(":\nwill_fail", tags: { source: "App::Main::Controller", dyno_number: "1", worker_index: "0" })
       StatsD.singleton_client.sink.shutdown
       assert_request_contents(TEST_URL, expected, expected_headers: { "Authorization" => "Bearer abc" })
     end

--- a/test/prometheus/serializer_test.rb
+++ b/test/prometheus/serializer_test.rb
@@ -10,6 +10,7 @@ module Prometheus
         nil,
         nil,
         nil,
+        nil,
       )
       output = serializer.run
       decoded_output = ::Prometheus::WriteRequest.decode(output)


### PR DESCRIPTION
[[PLT-515] Add worker_index label to prometheus metrics](https://github.com/meetcleo/statsd-instrument/commit/7b767e96c25f5e29d136e76aed18c6419fe06930) 
This label serves as a replacement to `pid`. It will store the index of the worker process (where we run multiple worker processes in our environments).

We are adding this to ensure when multiple workers write to the prometheus endpoint simultaneously that they do not get deduped.

[Remove default percentile calculations](https://github.com/meetcleo/statsd-instrument/commit/e40f90240fb0a696f32f3dbffe990e77d7787c4c) 
We aren't using these, so removing them so they don't add metrics to our storage.

[PLT-515]: https://cleo.atlassian.net/browse/PLT-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ