### PR TITLE
[PLT-913] Swap Net:HTTP with HTTPX

### DIFF
--- a/lib/statsd/instrument/dispatcher.rb
+++ b/lib/statsd/instrument/dispatcher.rb
@@ -44,7 +44,7 @@ module StatsD
 
         StatsD.logger.warn do
           "[#{self.class.name}] Failed to buffer event, thread_healthcheck: #{thread_healthcheck}, buffer_closed? #{@buffer.closed?}, buffer_empty? #{@buffer.empty?}, buffer_size #{@buffer.size}, buffer_max #{@buffer.max}"
-        end
+        end unless @interrupted
 
         result
       end

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -55,7 +55,7 @@ module StatsD
         retried = false
         begin
           yield
-        rescue SocketError, IOError, SystemCallError, Net::OpenTimeout => error
+        rescue SocketError, IOError, SystemCallError, Net::OpenTimeout, Errno::CONNREFUSED, HTTPX::HTTPError => error
           StatsD.logger.debug do
             "[StatsD::Instrument::UDPSink] Resetting connection because of #{error.class}: #{error.message}"
           end

--- a/statsd-instrument.gemspec
+++ b/statsd-instrument.gemspec
@@ -26,4 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'google-protobuf'
   # For compressing data sent to Prometheus
   spec.add_dependency 'snappy'
+  # For making requests to Prometheus
+  spec.add_dependency 'httpx'
 end

--- a/test/prometheus/integration_test.rb
+++ b/test/prometheus/integration_test.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "webmock"
+require "httpx/adapters/webmock"
 require "webmock/minitest"
 
 module Prometheus


### PR DESCRIPTION
This swaps the http library from Net:HTTP to HTTPX for prometheus sending.

We are doing this because Net:HTTP spawns a thread to track connection timeouts, which is not possible to do when Rails is shutting down. This was causing us to report errors at every shutdown as well as to miss sending the last batch of metrics before a shutdown. HTTPX works differently under the hood and is thus not prone to these errors.

e.g. gets rid of 
```
/app/bin/rails: warning: Exception in finalizer #<Proc:0x00007fde57143fb0 /app/vendor/bundle/ruby/3.3.0/bundler/gems/statsd-instrument-75bf6aab8225/lib/statsd/instrument/prometheus/batched_prometheus_sink.rb:16>
/app/vendor/ruby-3.3.1/lib/ruby/3.3.0/timeout.rb:98:in `new': can't alloc thread (ThreadError)
	from /app/vendor/ruby-3.3.1/lib/ruby/3.3.0/timeout.rb:98:in `create_timeout_thread'
	from /app/vendor/ruby-3.3.1/lib/ruby/3.3.0/timeout.rb:131:in `block in ensure_timeout_thread_created'
	from /app/vendor/ruby-3.3.1/lib/ruby/3.3.0/timeout.rb:129:in `synchronize'
	from /app/vendor/ruby-3.3.1/lib/ruby/3.3.0/timeout.rb:129:in `ensure_timeout_thread_created'
	from /app/vendor/ruby-3.3.1/lib/ruby/3.3.0/timeout.rb:178:in `timeout'
```