### PR TITLE
[PLT-913] Add integration test for failure path

### DIFF
--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -15,7 +15,7 @@ module StatsD
           end
 
           def close_socket(socket)
-            socket&.finish
+            socket&.close
           end
 
           def thread_name

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -55,7 +55,7 @@ module StatsD
         retried = false
         begin
           yield
-        rescue SocketError, IOError, SystemCallError, Net::OpenTimeout, Errno::CONNREFUSED, HTTPX::HTTPError => error
+        rescue SocketError, IOError, SystemCallError, Net::OpenTimeout, Errno::ECONNREFUSED, HTTPX::HTTPError => error
           StatsD.logger.debug do
             "[StatsD::Instrument::UDPSink] Resetting connection because of #{error.class}: #{error.message}"
           end
@@ -66,7 +66,7 @@ module StatsD
             end
           else
             retried = true
-            retry
+            retry if retries_allowed?
           end
         end
       end
@@ -88,6 +88,10 @@ module StatsD
 
       def thread_store
         Thread.current[self.class.thread_name] ||= {}
+      end
+
+      def retries_allowed?
+        true
       end
     end
   end

--- a/test/prometheus/integration_test.rb
+++ b/test/prometheus/integration_test.rb
@@ -99,5 +99,12 @@ module Prometheus
       StatsD.singleton_client.sink.shutdown
       assert_request_contents(TEST_URL, expected, expected_headers: { "Authorization" => "Bearer abc" })
     end
+
+    def test_request_failure
+      stub_request(:post, TEST_URL).to_return(status: 401)
+      StatsD.increment("counter", tags: { source: "App::Main::Controller", dyno_number: "1", worker_index: "0" })
+      StatsD::Instrument::Prometheus::PrometheusSink.any_instance.expects(:retries_allowed?).returns(false)
+      StatsD.singleton_client.sink.shutdown
+    end
   end
 end


### PR DESCRIPTION
Adds an integration test to ensure the failure path is tested. This highlighted two issues with the Net:HTTP -> HTTPX swap, which I've fixed.

Found these issues when testing on staging-2.