### PR TITLE
[PLT-913] Improve HTTPX connection and error handling

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
   - ./lib/statsd/instrument/rubocop.rb
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.3
   UseCache: true
   SuggestExtensions: false
   CacheRootDirectory: /tmp/rubocop

--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -119,6 +119,7 @@ module StatsD
           end
 
           socket
+            .plugin(:persistent)
             .with(origin: uri.origin)
             .with(timeout: { connect_timeout: open_timeout, write_timeout: write_timeout, read_timeout: read_timeout })
         end

--- a/lib/statsd/instrument/prometheus/prometheus_sink.rb
+++ b/lib/statsd/instrument/prometheus/prometheus_sink.rb
@@ -67,14 +67,8 @@ module StatsD
           invalidate_socket_and_retry_if_error do
             @number_of_requests_attempted += 1
             response = make_request(datagram)
-            if [201, 200].include?(response.status)
-              @number_of_requests_succeeded += 1
-            else
-              StatsD.logger.warn do
-                "[#{self.class.name}] Events were dropped because of response status from Prometheus: #{response.status}"
-              end
-              response.raise_for_status # https://honeyryderchuck.gitlab.io/httpx/wiki/Error-Handling#error-pattern-matching
-            end
+            response.raise_for_status # https://honeyryderchuck.gitlab.io/httpx/wiki/Error-Handling#error-pattern-matching
+            @number_of_requests_succeeded += 1
           end
           @last_flush_initiated_time = current_flush_initiated_time
           self

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -55,7 +55,7 @@ module StatsD
         retried = false
         begin
           yield
-        rescue SocketError, IOError, SystemCallError, Net::OpenTimeout, Errno::ECONNREFUSED, HTTPX::HTTPError => error
+        rescue SocketError, IOError, SystemCallError, Net::OpenTimeout, Errno::ECONNREFUSED, HTTPX::Error => error
           StatsD.logger.debug do
             "[StatsD::Instrument::UDPSink] Resetting connection because of #{error.class}: #{error.message}"
           end

--- a/lib/statsd/instrument/udp_sink.rb
+++ b/lib/statsd/instrument/udp_sink.rb
@@ -51,6 +51,12 @@ module StatsD
 
       private
 
+      def log_events_dropped(error)
+        StatsD.logger.warn do
+          "[#{self.class.name}] Events were dropped because of #{error.class}: #{error.message}"
+        end
+      end
+
       def invalidate_socket_and_retry_if_error
         retried = false
         begin
@@ -61,13 +67,13 @@ module StatsD
           end
           invalidate_socket
           if retried
-            StatsD.logger.warn do
-              "[#{self.class.name}] Events were dropped because of #{error.class}: #{error.message}"
-            end
+            log_events_dropped(error)
           else
             retried = true
             retry if retries_allowed?
           end
+        rescue ThreadError => error
+          log_events_dropped(error)
         end
       end
 


### PR DESCRIPTION
[[PLT-913] Fix error case](https://github.com/meetcleo/statsd-instrument/commit/2184fa00af9d113096c0545297e190dec3b7e7a3) 
This shifts up the `raise_for_status` call on the response so that we do not need to be aware of the response class.

Fixes a `The dispatcher thread encountered an error NoMethodError: undefined method `status' for an instance of HTTPX::ErrorResponse` exception that was happening because we were always checking the response `status` regardless of the response class.

[[PLT-913] Use persistent connections](https://github.com/meetcleo/statsd-instrument/commit/f8665917303c5f45c31ece35dd140021b42b4ba3) 
This will ensure HTTPX uses persistent connections, see: https://honeyryderchuck.gitlab.io/httpx/wiki/Persistent

I noticed some slowdown with prometheus request performance after shipping HTTPX and am chalking it up to the fact that the implementation with Net:Http was using a persistent connection.

[PLT-913]: https://cleo.atlassian.net/browse/PLT-913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PLT-913]: https://cleo.atlassian.net/browse/PLT-913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ